### PR TITLE
use brand_raw instead of brand for cpuinfo

### DIFF
--- a/scripts/arline-latex-report-generator
+++ b/scripts/arline-latex-report-generator
@@ -597,7 +597,7 @@ if __name__ == "__main__":
         with doc.create(Section("System Info")):
             with doc.create(Itemize()) as itemize:
                 itemize.add_item(f"Platform: {platform.platform(aliased=1)}")
-                itemize.add_item(f"Processor: {cpuinfo.get_cpu_info()['brand']}")
+                itemize.add_item(f"Processor: {cpuinfo.get_cpu_info()['brand_raw']}")
                 memory = virtual_memory().total / 2 ** 30
                 itemize.add_item(f"Memory: {round(memory, 1)} Gb")
 


### PR DESCRIPTION
Hi, I've seen that current versions of `cpuinfo` return no `brand` but a `brand_raw`.